### PR TITLE
Parcel: update to nightly

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "manatea": "^0.5.0-beta.6"
   },
   "devDependencies": {
-    "@parcel/transformer-typescript-tsc": "^2.0.0-beta.3.1",
+    "@parcel/transformer-typescript-tsc": "nightly",
     "@types/d3-color": "^3.0.2",
-    "parcel": "^2.0.0-beta.3.1",
+    "parcel": "nightly",
     "serve": "^11.3.2",
     "typescript": "4.3.5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,102 +282,102 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@parcel/babel-ast-utils@2.0.0-nightly.2377+79923ce5":
-  version "2.0.0-nightly.2377"
-  resolved "https://registry.yarnpkg.com/@parcel/babel-ast-utils/-/babel-ast-utils-2.0.0-nightly.2377.tgz#dae919e7c190ff3546afa1024e10ef07de7fdf4a"
-  integrity sha512-8G4eN/inzCfz5mYditlk6Yf6IHldH2plUIvhfPn5j3vUezT2hltQ/hMAIHqkvWseOVS2lyMy2sAVjeTKCqIezw==
+"@parcel/babel-ast-utils@2.0.0-nightly.2400+ba7d2263":
+  version "2.0.0-nightly.2400"
+  resolved "https://registry.yarnpkg.com/@parcel/babel-ast-utils/-/babel-ast-utils-2.0.0-nightly.2400.tgz#c19ffbb1038fd7c9a4c145686a860d05eac56b31"
+  integrity sha512-OQhEmWzew0MsKLTC9Ei1YyTwJgRH1QuAKJzEMln+Gc63d2jcci6PXnrLxC1dyGrkQEOS2BkAc9tFTn4wHsbf2w==
   dependencies:
     "@babel/parser" "^7.0.0"
-    "@parcel/babylon-walk" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/babylon-walk" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     astring "^1.6.2"
 
-"@parcel/babylon-walk@2.0.0-nightly.2377+79923ce5":
-  version "2.0.0-nightly.2377"
-  resolved "https://registry.yarnpkg.com/@parcel/babylon-walk/-/babylon-walk-2.0.0-nightly.2377.tgz#fe59bfac6d25912f35d9972939e09e24166340c1"
-  integrity sha512-l89ILAv6PPseT58rjUUsHNR30VmxP0SYuUvX4mcLWmGHzJS1TlLhFnQllXq5+3uve/IsrzV/wbhgks1IpmsTyQ==
+"@parcel/babylon-walk@2.0.0-nightly.2400+ba7d2263":
+  version "2.0.0-nightly.2400"
+  resolved "https://registry.yarnpkg.com/@parcel/babylon-walk/-/babylon-walk-2.0.0-nightly.2400.tgz#e6dd7edac36f661f40e8145d275ac63c161a238b"
+  integrity sha512-8mky+u3sa8r1wbhWtE7NbE6pEQN7/s5y7Rl7UGV6xElqWUPQN2dGAmRYHiuM69yC6pXi77MRWVrBSQqKaevTOQ==
   dependencies:
     "@babel/types" "^7.12.13"
     lodash.clone "^4.5.0"
 
-"@parcel/bundler-default@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/bundler-default/-/bundler-default-2.0.0-nightly.755.tgz#27249469e7d3a620ac993a6078046f76b3f779b3"
-  integrity sha512-AM7G+18Zsr9BpD7dST1/3q74hSD66K0Eg5/au3b7l2hkgbuQAg9YCX6itcjrI97PicwHR3YuVhiVt8FvSnYrqg==
+"@parcel/bundler-default@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/bundler-default/-/bundler-default-2.0.0-nightly.778.tgz#cddff1a123f760bbd516b299a8c3f38a68ab09a3"
+  integrity sha512-Aheu8//Lw5eEJQlGWtuon1E+ag/r4KjflNHUlfd2bYUvaKnJaQUqrVX6rc4gKYKhTfuhZGyT6TNmLOKiS5P3iA==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/hash" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/hash" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     nullthrows "^1.1.1"
 
-"@parcel/cache@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/cache/-/cache-2.0.0-nightly.755.tgz#688ff07561ae2fd48467ce61a63dfaa28bf5bf38"
-  integrity sha512-BKNTfbOpHkn631YRf44Gp0Jfkp86u/pvKbVX8xsQk6P0/dXr405pCc0JLPaZ6ReSDFGsikjhXwoWSGiTR7S9hg==
+"@parcel/cache@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/cache/-/cache-2.0.0-nightly.778.tgz#d4ce0d5d3d2cdf926f42087c7dc0f40012dcc38c"
+  integrity sha512-ePLvWCUpJmYMwyMyDmVK2Y+Wekj0HXYL27vnmNeImow30MdCPcsVUyA2x/V/xxmIU0hvwcC23oBDVQiMCfE/dw==
   dependencies:
-    "@parcel/logger" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/logger" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     lmdb-store "^1.5.5"
 
-"@parcel/codeframe@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/codeframe/-/codeframe-2.0.0-nightly.755.tgz#6a760756fc9200c4fa9269487152437094cab831"
-  integrity sha512-a+cmIqHQenef07AZfNd8+4d9bDi95EJmg0Et2nJGBGrHKbu6Z1RNxz60++NdRu4Hc01rA1GH7LnJ9hB4AxEh+g==
+"@parcel/codeframe@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/codeframe/-/codeframe-2.0.0-nightly.778.tgz#4b5932784cffc2cd10dd9f161b03cbae3d30bada"
+  integrity sha512-Rr0TZ0aGRrcoY3sSOClvd/peWOOqT54Hql/howfK3hAhuxy9JoU5T09snYA3gQmKkka9NhKDQk/hxqbVHg4FuA==
   dependencies:
     chalk "^4.1.0"
     emphasize "^4.2.0"
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
 
-"@parcel/config-default@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/config-default/-/config-default-2.0.0-nightly.755.tgz#440da7a416300191e39f3b83d0b1798c7e42178d"
-  integrity sha512-Rf99nS6e6LxetDPn7ZqRRC/XXfyU8yMFYuUEkzEZLprdw6ddq2013qYRARMIMHpbykDrhsZzvF7sZURlIeVgHQ==
+"@parcel/config-default@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/config-default/-/config-default-2.0.0-nightly.778.tgz#a60704c0672d91ea2613711302dc8b3d8bdac3e4"
+  integrity sha512-pyGmjv4TWBeBT347QNKJW4v0Nvylm+GE5hnfFuy0wXde8tIS+JSGq++n/k3qm4LH5Dm6ARMA2Io/OIopqT0iAw==
   dependencies:
-    "@parcel/bundler-default" "2.0.0-nightly.755+79923ce5"
-    "@parcel/namer-default" "2.0.0-nightly.755+79923ce5"
-    "@parcel/optimizer-cssnano" "2.0.0-nightly.755+79923ce5"
-    "@parcel/optimizer-htmlnano" "2.0.0-nightly.755+79923ce5"
-    "@parcel/optimizer-svgo" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/optimizer-terser" "2.0.0-nightly.755+79923ce5"
-    "@parcel/packager-css" "2.0.0-nightly.755+79923ce5"
-    "@parcel/packager-html" "2.0.0-nightly.755+79923ce5"
-    "@parcel/packager-js" "2.0.0-nightly.755+79923ce5"
-    "@parcel/packager-raw" "2.0.0-nightly.755+79923ce5"
-    "@parcel/reporter-dev-server" "2.0.0-nightly.755+79923ce5"
-    "@parcel/resolver-default" "2.0.0-nightly.755+79923ce5"
-    "@parcel/runtime-browser-hmr" "2.0.0-nightly.755+79923ce5"
-    "@parcel/runtime-js" "2.0.0-nightly.755+79923ce5"
-    "@parcel/runtime-react-refresh" "2.0.0-nightly.755+79923ce5"
-    "@parcel/transformer-babel" "2.0.0-nightly.755+79923ce5"
-    "@parcel/transformer-css" "2.0.0-nightly.755+79923ce5"
-    "@parcel/transformer-html" "2.0.0-nightly.755+79923ce5"
-    "@parcel/transformer-js" "2.0.0-nightly.755+79923ce5"
-    "@parcel/transformer-json" "2.0.0-nightly.755+79923ce5"
-    "@parcel/transformer-postcss" "2.0.0-nightly.755+79923ce5"
-    "@parcel/transformer-posthtml" "2.0.0-nightly.755+79923ce5"
-    "@parcel/transformer-raw" "2.0.0-nightly.755+79923ce5"
-    "@parcel/transformer-react-refresh-wrap" "2.0.0-nightly.755+79923ce5"
+    "@parcel/bundler-default" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/namer-default" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/optimizer-cssnano" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/optimizer-htmlnano" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/optimizer-svgo" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/optimizer-terser" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/packager-css" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/packager-html" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/packager-js" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/packager-raw" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/reporter-dev-server" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/resolver-default" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/runtime-browser-hmr" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/runtime-js" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/runtime-react-refresh" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/transformer-babel" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/transformer-css" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/transformer-html" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/transformer-js" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/transformer-json" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/transformer-postcss" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/transformer-posthtml" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/transformer-raw" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/transformer-react-refresh-wrap" "2.0.0-nightly.778+ba7d2263"
 
-"@parcel/core@2.0.0-nightly.753+79923ce5":
-  version "2.0.0-nightly.753"
-  resolved "https://registry.yarnpkg.com/@parcel/core/-/core-2.0.0-nightly.753.tgz#10ea2f77e4cb2f098422a23e50ae4228100e27b9"
-  integrity sha512-t7dOcsA4Cp5eYpBSyyA00eVzc89jX7ipzH7Hq1VrOvliD8PEZ0i8y9YjmhsIgpLl1FuMkOc7PSElWyKDXu7kvQ==
+"@parcel/core@2.0.0-nightly.776+ba7d2263":
+  version "2.0.0-nightly.776"
+  resolved "https://registry.yarnpkg.com/@parcel/core/-/core-2.0.0-nightly.776.tgz#d8e04255a94cfdca93eacd5b9a25d41679cb6dc3"
+  integrity sha512-Q5zscbcAuNSZDLGdgdC81s/eCwuSYsC5tUQJJ7XQqhmcDANhMtXTJxPlJOv2ebkULhIjI5KtYQLVZBP69ICIXg==
   dependencies:
-    "@parcel/cache" "2.0.0-nightly.755+79923ce5"
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/events" "2.0.0-nightly.755+79923ce5"
-    "@parcel/fs" "2.0.0-nightly.755+79923ce5"
-    "@parcel/hash" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/logger" "2.0.0-nightly.755+79923ce5"
-    "@parcel/package-manager" "2.0.0-nightly.755+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
-    "@parcel/types" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
-    "@parcel/workers" "2.0.0-nightly.755+79923ce5"
+    "@parcel/cache" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/events" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/fs" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/hash" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/logger" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/package-manager" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
+    "@parcel/types" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/workers" "2.0.0-nightly.778+ba7d2263"
     abortcontroller-polyfill "^1.1.9"
     base-x "^3.0.8"
     browserslist "^4.6.6"
@@ -391,47 +391,47 @@
     querystring "^0.2.0"
     semver "^5.4.1"
 
-"@parcel/diagnostic@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/diagnostic/-/diagnostic-2.0.0-nightly.755.tgz#adcccafedd4456b177a1c637789cd569a958c555"
-  integrity sha512-/T7sd+JRYF3xlVYWpMXutsWLss9MByBJZkaES0YOVG3TOIi27zVuH9xX9h3OwiqcNYmRePSYi0naeHd79ljM1A==
+"@parcel/diagnostic@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/diagnostic/-/diagnostic-2.0.0-nightly.778.tgz#3bf41d42ef013d0c3559b26a611c86def2edba38"
+  integrity sha512-dwAMeX0DoKwPR4FqyzOZPPwPv8RddGluj0Te8AaBRO2OaxBwKpsO7nxdJrpCbmXM67WkIrkquFFFX8U5sL2qZQ==
   dependencies:
     json-source-map "^0.6.1"
     nullthrows "^1.1.1"
 
-"@parcel/events@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/events/-/events-2.0.0-nightly.755.tgz#69ca8543a39f26908daf6b0023119a7c34e826b6"
-  integrity sha512-Ov/0O36WWOuPpCGBLzbPJNIXZiwL8rZBIkjmxvpSByKI95MPvCpvUylHx6RsHSRHpFBuM5SfT29Bweh7Whd8xg==
+"@parcel/events@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/events/-/events-2.0.0-nightly.778.tgz#43d7fb073d8b9fecae499f95f9b4d23530ff1576"
+  integrity sha512-k/RDNh8Ub8YOF44d/LGikZnp3slOfxV6mfkQjAIZuzNPxqtMrzxPHZ2N63shp1XllrLpYQQfJqaPdWLCjoTV+w==
 
-"@parcel/fs-search@2.0.0-nightly.2377+79923ce5":
-  version "2.0.0-nightly.2377"
-  resolved "https://registry.yarnpkg.com/@parcel/fs-search/-/fs-search-2.0.0-nightly.2377.tgz#d208c7749c0a8fa94c18d5890426536e365b0bb6"
-  integrity sha512-UwgTA1bySTnoGAQ0tTYMXkO5QNiick8OEnT1lkv8pvnLUKivBtOiz6AqCixHcJUZkMNws5+fpeXXhhrm++lR3w==
+"@parcel/fs-search@2.0.0-nightly.2400+ba7d2263":
+  version "2.0.0-nightly.2400"
+  resolved "https://registry.yarnpkg.com/@parcel/fs-search/-/fs-search-2.0.0-nightly.2400.tgz#332424eceeba273ef4771b461d519d85d0b0e2f9"
+  integrity sha512-SA+NKXxw45qxvx0pLsdUMXpBgl9guCfJY4MvEh+KEcIVGj/27NeEV1z1snlig8nGS0lMd4rZZxm+gfyICHsXPg==
   dependencies:
     detect-libc "^1.0.3"
 
-"@parcel/fs-write-stream-atomic@2.0.0-nightly.2377+79923ce5":
-  version "2.0.0-nightly.2377"
-  resolved "https://registry.yarnpkg.com/@parcel/fs-write-stream-atomic/-/fs-write-stream-atomic-2.0.0-nightly.2377.tgz#a7a29cd8471bd6d9482f4883d5d74ed8cb8a2e88"
-  integrity sha512-+l8f6fCtdX92taLUZJ6C2GqE4gQUTbKsGufijT5IamELBBTa37jABNbbj/w194qPZfoA7roeTD1gzRyRnqHUwA==
+"@parcel/fs-write-stream-atomic@2.0.0-nightly.2400+ba7d2263":
+  version "2.0.0-nightly.2400"
+  resolved "https://registry.yarnpkg.com/@parcel/fs-write-stream-atomic/-/fs-write-stream-atomic-2.0.0-nightly.2400.tgz#4daa98d660682bc3b1ac4b8203b9da3e3107eb19"
+  integrity sha512-t4e/lPr2wHho1YRTLVpnCYCKho+PCQFpMeR0c4YrXNSe889kXGjX4qyA2J115JbrShyrjTeoqejaMmS/uAqfAw==
   dependencies:
     graceful-fs "^4.1.2"
     iferr "^1.0.2"
     imurmurhash "^0.1.4"
     readable-stream "1 || 2"
 
-"@parcel/fs@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/fs/-/fs-2.0.0-nightly.755.tgz#e4a31031700e11346d55d26b1c83d5c501a6cc84"
-  integrity sha512-OGNW1OwfZn/vxU55z2W9Zohv/vD5QQQXKBYCW3R7Eli/gbvAGQV2BXoYpPx0WIN4DjDS1hh0YWyJaJ+wuKYMkw==
+"@parcel/fs@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/fs/-/fs-2.0.0-nightly.778.tgz#53806f8435e5af9730afa9211ac43defc6dc7138"
+  integrity sha512-dzvZ8JhrIUK3y8IbQYK/Wugs1GTu0g2+aQzywyhY+cCQ2tqM88aS5qtWKprugCu5qpAc2lwHbsz2SQLyVJ5T7w==
   dependencies:
-    "@parcel/fs-search" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/fs-write-stream-atomic" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/types" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/fs-search" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/fs-write-stream-atomic" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/types" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     "@parcel/watcher" "2.0.0-alpha.10"
-    "@parcel/workers" "2.0.0-nightly.755+79923ce5"
+    "@parcel/workers" "2.0.0-nightly.778+ba7d2263"
     graceful-fs "^4.2.4"
     mkdirp "^0.5.1"
     ncp "^2.0.0"
@@ -439,42 +439,42 @@
     rimraf "^3.0.2"
     utility-types "^3.10.0"
 
-"@parcel/hash@2.0.0-nightly.2377+79923ce5":
-  version "2.0.0-nightly.2377"
-  resolved "https://registry.yarnpkg.com/@parcel/hash/-/hash-2.0.0-nightly.2377.tgz#bfe54a64ab3c084e42fa59b795e12b8d1a6a83a2"
-  integrity sha512-/sfvj0H+F4aV2L1GlA8Tvo6yWavP95xdUZl45wvJ8YMaceLtMIVt7grHFZTDEV08Q/FrwvaRUzo6iCCFlPb0XA==
+"@parcel/hash@2.0.0-nightly.2400+ba7d2263":
+  version "2.0.0-nightly.2400"
+  resolved "https://registry.yarnpkg.com/@parcel/hash/-/hash-2.0.0-nightly.2400.tgz#8a9b63a43a1a634889979842780c648d5102126e"
+  integrity sha512-P7RTcCJTD79w5JoxO/2CnpwrqlFJN6N9obUh1u+c7Y1QzyZe4Z99II0jl1qYsEtFhM3inaRFko6gQM5yUJ/rZg==
   dependencies:
     detect-libc "^1.0.3"
     xxhash-wasm "^0.4.1"
 
-"@parcel/logger@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/logger/-/logger-2.0.0-nightly.755.tgz#b1c814e3cdc1a6f936262071b2e8a4af4bbc69c6"
-  integrity sha512-HJz166L5wUd4SRpK05+MuLEiXgwvKJFOOOty0aT9gyQyNo9lEwl7bmSXY93oyBa2ph5/m1Hh/Yyvi/vzKrqTqg==
+"@parcel/logger@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/logger/-/logger-2.0.0-nightly.778.tgz#0ab84f1e6b230cf64dc92cfff8ae834128932ec3"
+  integrity sha512-Cznlnnv1wPf6oMKJIFqetg/1KNgC0zA8c9OtaYeZXT0S6Hvjcxd6o0eNf/A2mrEuAzxTg3xhZ5Scwr74UKl54Q==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/events" "2.0.0-nightly.755+79923ce5"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/events" "2.0.0-nightly.778+ba7d2263"
 
-"@parcel/markdown-ansi@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-nightly.755.tgz#9efae76e89378eb9a6ba328c6e7fc699ebaff2bb"
-  integrity sha512-1lCWTo5XEzNpsVyzLgQkwKV5BOQTj+FeYN+2MpH7idcKfJMMJi1MU+bts6/ulkKVOC56G8/R4gMQFAd92qLtMg==
+"@parcel/markdown-ansi@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-nightly.778.tgz#4dc34cb7a3ddf0e9accc9e324c92dc057baa625c"
+  integrity sha512-Kctk8exaG/b6PRp6uBoyQBDg/yIMA9SnqPiRsG4yFX3t5mfDKRm7FN4DmDNLMe5M2NR4I68d1zIt39sljlIp+w==
   dependencies:
     chalk "^4.1.0"
 
-"@parcel/namer-default@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/namer-default/-/namer-default-2.0.0-nightly.755.tgz#8c3a23a6ccdc5f50201024070cde3831c0db5ab0"
-  integrity sha512-PPxEwK8WkKyixkZSmJMn0Pxcbx7uKDHdEGoRSkUVCgWZnPkZVxNdT9zPC+l1iKQr2TE/XLy/QpMboeWPi3Mzcw==
+"@parcel/namer-default@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/namer-default/-/namer-default-2.0.0-nightly.778.tgz#c1de54ab36a888d12ed1001c0f4608df66706bd2"
+  integrity sha512-YWYvtmz9A0oHh6TmOASu1+W6iofrfcxGiSdPkWmoBMFV3dzLLItnHF18+9SoTeKLPXlJiTTVnESjORedY2GLDg==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
     nullthrows "^1.1.1"
 
-"@parcel/node-libs-browser@2.0.0-nightly.2377+79923ce5":
-  version "2.0.0-nightly.2377"
-  resolved "https://registry.yarnpkg.com/@parcel/node-libs-browser/-/node-libs-browser-2.0.0-nightly.2377.tgz#1ffc9f72c8324f294869d63525183e7ba917054c"
-  integrity sha512-lQk7Sx60FCmhywwq7/RVJBD9zqOBhAtTNmNPTCX1+46MtIlzrTuXxLF0joiSHvc/wPE8fCtJoh8xftDl4Cx1bA==
+"@parcel/node-libs-browser@2.0.0-nightly.2400+ba7d2263":
+  version "2.0.0-nightly.2400"
+  resolved "https://registry.yarnpkg.com/@parcel/node-libs-browser/-/node-libs-browser-2.0.0-nightly.2400.tgz#609cc66666f0315b0c5ec9139d97273e96dfdac9"
+  integrity sha512-zTYWlaoyDgJSg1vmhlhZAFE5WrnKsh6Yy+KBPs26cdCJ2ykAwzXIW/hhAkrgE5OQImPeLZcQWsKCOGK0pQRfjw==
   dependencies:
     assert "^2.0.0"
     browserify-zlib "^0.2.0"
@@ -499,134 +499,135 @@
     util "^0.12.3"
     vm-browserify "^1.1.2"
 
-"@parcel/node-resolver-core@2.0.0-nightly.2377+79923ce5":
-  version "2.0.0-nightly.2377"
-  resolved "https://registry.yarnpkg.com/@parcel/node-resolver-core/-/node-resolver-core-2.0.0-nightly.2377.tgz#41f63cc1eb9e7df35eabee0e34623a4f1a4d8190"
-  integrity sha512-uoSSGdwo53o5DFHhr9JVpnVMjmWc2sYU5izB5VWXRDdpDS2n8wXfS5PaGz5cD3GMdtD/L2w6LwtydkyRLppLMQ==
+"@parcel/node-resolver-core@2.0.0-nightly.2400+ba7d2263":
+  version "2.0.0-nightly.2400"
+  resolved "https://registry.yarnpkg.com/@parcel/node-resolver-core/-/node-resolver-core-2.0.0-nightly.2400.tgz#fea35afebf3f342572d75de4f120cfa7adf15678"
+  integrity sha512-FFaH7O8TiFHxB16vuzW3n8smHOb5gpWaOaMYI3TOaQ3no+y/wIhf4l2ml8sKJ3Ea3y+9YafPkeFXj/BdPbBXiA==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/node-libs-browser" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/node-libs-browser" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     micromatch "^3.0.4"
     nullthrows "^1.1.1"
     querystring "^0.2.0"
 
-"@parcel/optimizer-cssnano@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-cssnano/-/optimizer-cssnano-2.0.0-nightly.755.tgz#0784aefa78885a6cb9c60e8493e9fa8a0fad54f3"
-  integrity sha512-C/NM7PnzL8BpEiIUscAIfw/yexkp1I6d4xLtMOfPyatjaNwR9XiNNun+WqPisTr4TXS7WFTcHf3EmcXQLtV8+g==
+"@parcel/optimizer-cssnano@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-cssnano/-/optimizer-cssnano-2.0.0-nightly.778.tgz#1ee9069b592d512ec5170c4a9f6fdb0b81139cb3"
+  integrity sha512-wUiX1kRq5VgZd08bmja2Qrlk+hnV1PszbOyAPj1ZnNEue5GROEjSZ6RLiKdaiIXDTOf3QaVZTrARAvTVVYTSvw==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
     cssnano "^5.0.5"
     postcss "^8.3.0"
 
-"@parcel/optimizer-htmlnano@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.0.0-nightly.755.tgz#03873a168d73840b1a90deb8c57cde50e3e0702c"
-  integrity sha512-oe5nFnFrSkZCrJ2yevztJyhjOlAMxgV+8n6/0SuY6wopAgaYOrJI8yQx9oBfsqfsjJ8idc2zudYFlUzz8ltxaA==
+"@parcel/optimizer-htmlnano@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.0.0-nightly.778.tgz#d2093d7ee7f75f4b9f96eb8e3a664dd1d64d2a65"
+  integrity sha512-KuUDrH/B+oaUhZ7dWHHaVPjwdiafKiGTECCWiiiC81/YbOCARTA0R8M+RFXnO6ojh+jKuV45i3oKkuX0uNVLsA==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
     htmlnano "^1.0.0"
     nullthrows "^1.1.1"
-    posthtml "^0.15.1"
-
-"@parcel/optimizer-svgo@2.0.0-nightly.2377+79923ce5":
-  version "2.0.0-nightly.2377"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-svgo/-/optimizer-svgo-2.0.0-nightly.2377.tgz#4239782614f9395ed5d3213de58a62407461f2a2"
-  integrity sha512-v7+5orozMQ11NbLiLU4nyUqoYqGXPKuJeLV9U52FNqCFV5+qABLlMTE2cQc5kX+QL+PV9tK9nKdXwhM7wPRUPw==
-  dependencies:
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    posthtml "^0.16.4"
     svgo "^2.3.0"
 
-"@parcel/optimizer-terser@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/optimizer-terser/-/optimizer-terser-2.0.0-nightly.755.tgz#1b3bccd222cd420d11c7f3022544fc63811e4142"
-  integrity sha512-ZsxOWtPQXN2r0s/FRuJMFMJ/wbYL06XweQ1bQAKi7Vdfm85Y+jmLxF3VwgmjTfstf4DkwCHNizZvlAFrYsBqTQ==
+"@parcel/optimizer-svgo@2.0.0-nightly.2400+ba7d2263":
+  version "2.0.0-nightly.2400"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-svgo/-/optimizer-svgo-2.0.0-nightly.2400.tgz#dbeb2510bc4958f3c9061ae5d1169a1887fca5eb"
+  integrity sha512-5d48iSQBfjQROFf5mQKXChqhowt+5iHgw+vaZaxh6fdNJjRbCYLgNdkkrX7oOHgQZ8YJRGgIjoQ0P9JTnx+O2g==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
+    svgo "^2.3.0"
+
+"@parcel/optimizer-terser@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/optimizer-terser/-/optimizer-terser-2.0.0-nightly.778.tgz#ac23d15f913b332e28edb54c1b8c6145d158ad30"
+  integrity sha512-GsmgBfAJOjFPTkA49jynhGd+mPKCnZhNHsjsFljvfEjt4/O4vfwHbjm1WEZ7CpPNNSmg21ISh/thMCfwWjpZcg==
+  dependencies:
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     nullthrows "^1.1.1"
     terser "^5.2.0"
 
-"@parcel/package-manager@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/package-manager/-/package-manager-2.0.0-nightly.755.tgz#339bbd168ce96528e978f1077967ed42f39a2318"
-  integrity sha512-d8+cRfPvkhKTNhXl2yu8OTspGdUMlIPfBTTAGYm7Y+iWEnB3sALRHckdCQbRk48hLwR80QDZXQ+s87TEKbTczg==
+"@parcel/package-manager@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/package-manager/-/package-manager-2.0.0-nightly.778.tgz#0d4244b94f221231bf6033a032aaebacc081adb5"
+  integrity sha512-+PyNQo5IpvUW2q6Idf+bqoZj6jTMjCwb9I1bdnWKVQPUGeZ7SnVWn5XSoSgfhwsQJUbSST5k4GKbPqXYCeKWhA==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/fs" "2.0.0-nightly.755+79923ce5"
-    "@parcel/logger" "2.0.0-nightly.755+79923ce5"
-    "@parcel/types" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
-    "@parcel/workers" "2.0.0-nightly.755+79923ce5"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/fs" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/logger" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/types" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/workers" "2.0.0-nightly.778+ba7d2263"
     command-exists "^1.2.6"
     cross-spawn "^6.0.4"
     nullthrows "^1.1.1"
     semver "^5.4.1"
     split2 "^3.1.1"
 
-"@parcel/packager-css@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-css/-/packager-css-2.0.0-nightly.755.tgz#e460393072b5f4057758c30ad9dca6fbdabfc0c0"
-  integrity sha512-yU50ACWysDM/DMgldqyBPVZBQHruDF/VymmxToSPNTklT50Ah5KEgozF/vkvRkaKZYEWtBOrW19mbElWnQkFXQ==
+"@parcel/packager-css@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-css/-/packager-css-2.0.0-nightly.778.tgz#f25a252b4983876b7bfcada40005f29cfcd76fe3"
+  integrity sha512-iXhHt9pQGxY+Cz38CPNDQ7jY9YpqrCkbfsGvjk/vzAREfH279KtTSlyNVbZRzITYmPc307REPsVrNswBDsQWVQ==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     nullthrows "^1.1.1"
     postcss "^8.3.0"
 
-"@parcel/packager-html@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-html/-/packager-html-2.0.0-nightly.755.tgz#eb31c90f2c989e7bdc0e0f508f32f4b35ab6c1d2"
-  integrity sha512-RYOu5rosWWNmBNGS9Z1/1BRFSORhWiL2CbOBzdRgHz4H6DRBtZY57biHpD1CcZsct23Mg+DX9JMph7dGeE3MgA==
+"@parcel/packager-html@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-html/-/packager-html-2.0.0-nightly.778.tgz#6ac5c796e02d378c7af725b9d5d207193e9962a2"
+  integrity sha512-pMp9w97fcf89Mk+jpJ15LvpBfWdCjIfx1VBvSVW6g4FWx/bURY3aRNDOW7j6wcGfe+TiGmP36l/66Zr4lNiNxg==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/types" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/types" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     nullthrows "^1.1.1"
-    posthtml "^0.15.1"
+    posthtml "^0.16.4"
 
-"@parcel/packager-js@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-js/-/packager-js-2.0.0-nightly.755.tgz#c8507b7f9adb3dcbb6400f7d8a5027d11814808e"
-  integrity sha512-q3tJYldrwQHuJ7BYGaYNEMfzr9E7eIlqkKVwUN4+Ly0aAYS086VkKjtJTWs+PP0awBdUx9qRD5SaM10En5VOdw==
+"@parcel/packager-js@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-js/-/packager-js-2.0.0-nightly.778.tgz#3233d96b1b858210dc0af752b98223ba494591b5"
+  integrity sha512-LtNfNrsB0wP19uk496QudFtbtMsH1FZ/r9fXuMyw5oCRInWer73fROmCdex8RCyN08PoqnDr5HFrDVMDnkXdqA==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/hash" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/hash" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     globals "^13.2.0"
     nullthrows "^1.1.1"
 
-"@parcel/packager-raw@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/packager-raw/-/packager-raw-2.0.0-nightly.755.tgz#057939f71417985478243d6145a6ffb136974ede"
-  integrity sha512-vcOTal+xemlRt3if2PBfmzn2uMZ5GEDKYC5073zZnuWHpEheqk5biFDK9lWrCWdsUNgh9ZhQx7yRnQeI6gAXDA==
+"@parcel/packager-raw@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/packager-raw/-/packager-raw-2.0.0-nightly.778.tgz#cbf076ea61eeb3c42988c4e1fd286020091b7b45"
+  integrity sha512-junXGQItlwpfgbzJFrzkgfc7tH5FXsWllcuMQSJZ7yPAH3vof0DyvewBTB4XitdZwydfe+gDPzbYovrZcFNtXQ==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
 
-"@parcel/plugin@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/plugin/-/plugin-2.0.0-nightly.755.tgz#a16534f1abff7aec530e5fed03617b27890acb14"
-  integrity sha512-d/UgfSkspI4XC8BOot8r7smjuEk51EpaRteDH8XGeB6qbKRPjPtVwVDaCqFNfJpqJO+Bgt/VJGhk7WzP3JRB5Q==
+"@parcel/plugin@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/plugin/-/plugin-2.0.0-nightly.778.tgz#468cc1537aaec325a42543976dddaa19e096cd76"
+  integrity sha512-jjmGwMO/10lYKXTTllj6FqzEfTZXRqMqdlQ6jQ/CzNzDgI5lwfpkY0L+ABTFmZp/envK9ojX7qTCP5/OziDVHQ==
   dependencies:
-    "@parcel/types" "2.0.0-nightly.755+79923ce5"
+    "@parcel/types" "2.0.0-nightly.778+ba7d2263"
 
-"@parcel/reporter-cli@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/reporter-cli/-/reporter-cli-2.0.0-nightly.755.tgz#4f358bce4ec4ac1f7f3106228e282eb9d3b6ccf1"
-  integrity sha512-ztnKrufls4O71suj+hD0cMMqff8JN8CzANtRUsGDR9QTi3/bWuQ8BafWKAWkmkl7gtgX3sCntRPApfxh0FiCDw==
+"@parcel/reporter-cli@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/reporter-cli/-/reporter-cli-2.0.0-nightly.778.tgz#b30e03ead2b075c79515766d864223bf4d85371e"
+  integrity sha512-A+LzIcLe5RclEetks/ga2Vtf6x1+GmBHV20jgZD1j6uftufZFenzT+BZgKTTtebrIJ8iX+pNWqpIje1pfKDWEQ==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/types" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/types" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     chalk "^4.1.0"
     filesize "^6.1.0"
     nullthrows "^1.1.1"
@@ -636,13 +637,13 @@
     term-size "^2.2.1"
     wrap-ansi "^7.0.0"
 
-"@parcel/reporter-dev-server@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/reporter-dev-server/-/reporter-dev-server-2.0.0-nightly.755.tgz#6cf1eb983f8cece755cf4a7ae99f865d138fd2ae"
-  integrity sha512-y5R5Tu2cR/quGEfKmo9McYd5HlTQGhaYTSXTleaLL/NGkTuKBeGDxyBwIeLWd/6uPhJM7EUQydMYNbvj+Ux64A==
+"@parcel/reporter-dev-server@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/reporter-dev-server/-/reporter-dev-server-2.0.0-nightly.778.tgz#68a18b5243b430d8bb16e0faf6fc13676c2d38c6"
+  integrity sha512-eXAQho6lBgPIWU4bGCNGM3lDsS+ikdbMMC6IIFV00qcjgy00lTrjkPW7P4Vf2C9KogZTnKSKf0qKk8WY81guXg==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     connect "^3.7.0"
     ejs "^2.6.1"
     http-proxy-middleware "^1.0.0"
@@ -650,102 +651,102 @@
     serve-handler "^6.0.0"
     ws "^7.0.0"
 
-"@parcel/resolver-default@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/resolver-default/-/resolver-default-2.0.0-nightly.755.tgz#2f5505ddc75cf34ca5d8175855508e2e83b499be"
-  integrity sha512-4lGgqk9AXT3/EnHNYnRob6zLzlGiJ4A7lYBLcL5Pgun+fBMeSN0U+1Au2kDb8Ma1BiOujQYhLVmhK+tNzLSKJg==
+"@parcel/resolver-default@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/resolver-default/-/resolver-default-2.0.0-nightly.778.tgz#1be0efd2782119545a4ce97653352af490c32582"
+  integrity sha512-0S4mWFt1EL5L2JIxwPBUpXLmlxJkWiKxf3SAgE1O+e3jeZVdq6m9foKSSGlThsY5+RZe79DYb409adQXRUKHXw==
   dependencies:
-    "@parcel/node-resolver-core" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
+    "@parcel/node-resolver-core" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
 
-"@parcel/runtime-browser-hmr@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.0.0-nightly.755.tgz#d15931b8be01bc1ad508a84dd7bf391413a7eff1"
-  integrity sha512-1bYllEVdBJcl2YQQsUykYsT5wLDKi+D8wLzQD2sf+T+x3Tc1kA1kxUmUcXnCPr+RbrAmubl91oFPgGbBPCDqpw==
+"@parcel/runtime-browser-hmr@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.0.0-nightly.778.tgz#4fd5d5834f89c6f575f1edc7d64168b604640d81"
+  integrity sha512-cyXQSbMhomjTf+mrkxW2gQlthbQFWz/IZ8wmyFQ2jPvnuosIK9loY0uGTlgGJSDemJkYG1zeAdSFGwzy+3h0mQ==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
 
-"@parcel/runtime-js@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-js/-/runtime-js-2.0.0-nightly.755.tgz#fff941871c010f828b5e28d1d17350d8ea68eb5f"
-  integrity sha512-gttjHWl71IM3CVKkwjDP7iYwu6ALZIMyi1tAesmwpjhxY/fVQXxrwGWM33hip4CBJGF1wpEgZDZUTxrW5Y6HZA==
+"@parcel/runtime-js@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-js/-/runtime-js-2.0.0-nightly.778.tgz#663561d4fc7a60dd849dc0bef6af8e0f0e3b8300"
+  integrity sha512-R8nt3jTbF2gHQ9NzaSNwfq9vtee4rL1fTd+3HaxcVB2lSu/7iaiKX8lOalAo717eUoQrqygKAjXRT/yOH7Gk1A==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     nullthrows "^1.1.1"
 
-"@parcel/runtime-react-refresh@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.0.0-nightly.755.tgz#396095608678c37ab1f81529f8f223b7ace70a82"
-  integrity sha512-dfdntp+/ZxhyNRnosvakfqydKZ3vVo3jrw8KB7YMzdBgM2787NxaAltXKleT9lCWmHl1ODL7LynETII7O+BwgA==
+"@parcel/runtime-react-refresh@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.0.0-nightly.778.tgz#54825d6b109ac7c875c9f174be100d60c8135c30"
+  integrity sha512-npMoRChT6X/YR9oQvCq3bUza+6EBiLjtz2uIw8HiqFPc7nst5QGUXnYGpDnWAxMUP3cbw1GF8Cc5V5EwoLRZFA==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     react-refresh "^0.9.0"
 
-"@parcel/source-map@2.0.0-rc.4":
-  version "2.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@parcel/source-map/-/source-map-2.0.0-rc.4.tgz#e2a58bde612b5e383d2b2ca9e81f07d592adfcde"
-  integrity sha512-Yl6pNy34YNQfXtx03CCTKTrV6X3hh7v2vSrFDzJe/m6HFSlc1/n2pz05bbPOoeojR8zVNRRVoAdSH0iDMKGRuQ==
+"@parcel/source-map@2.0.0-rc.5":
+  version "2.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@parcel/source-map/-/source-map-2.0.0-rc.5.tgz#4b63693911ace37d4f72c4e94b05494be827024e"
+  integrity sha512-hzajtRBcFjo90LiWHqWUazRyYUtPwtJ3n1g5w1Unw5aFtkacOW33K9rI2PDRTEj/4EMHcREHYhJGj7KmOAckAA==
   dependencies:
     detect-libc "^1.0.3"
     globby "^11.0.3"
 
-"@parcel/transformer-babel@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-babel/-/transformer-babel-2.0.0-nightly.755.tgz#d679cbb758605175af55b28c6eb1bad534e43a4b"
-  integrity sha512-kQYOrHdtgayMObN05SqWqt4VAz6tCMuP/CO8Db2OnGYXYUnCPztuwfgw8ZTMiAge5GcI3ZGr0SZa5YQHZOXtow==
+"@parcel/transformer-babel@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-babel/-/transformer-babel-2.0.0-nightly.778.tgz#1b5cc143bbed24276f13b6cb4f377742c5528bae"
+  integrity sha512-CGz48YA/Jbm/ZBXJ/s/RZCYBxlalVKOco3g8rC/QHSY47zxvgbrewWvWANrKIw8Q022CfgSmfY5IWlg6ZKg25w==
   dependencies:
     "@babel/core" "^7.12.0"
     "@babel/generator" "^7.9.0"
     "@babel/helper-compilation-targets" "^7.8.4"
     "@babel/plugin-transform-flow-strip-types" "^7.0.0"
     "@babel/traverse" "^7.0.0"
-    "@parcel/babel-ast-utils" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/babel-ast-utils" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     browserslist "^4.6.6"
     core-js "^3.2.1"
     nullthrows "^1.1.1"
     semver "^5.7.0"
 
-"@parcel/transformer-css@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-css/-/transformer-css-2.0.0-nightly.755.tgz#eeba4edbd376509e7b22ab24da6ef80f655c79ca"
-  integrity sha512-9t0L98DfRvuMtTL4X4WgIDtbXyE25MOHOkCxt+3cMvNW48drUywpnPPptS0FefzepFfwWhK5emX/XFtCEjwqSg==
+"@parcel/transformer-css@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-css/-/transformer-css-2.0.0-nightly.778.tgz#0f28ecc25e21c305eafd0b1ad4237f09c39dc169"
+  integrity sha512-GGFsV/iFZ5m9fGojJP80rkGeiPkYfhKKHTHYlsj3HUtMYYQDBFGGZ/xsQNXCTH2Yzwc0jdSJahP/G7wm/XZ3Kw==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     nullthrows "^1.1.1"
     postcss "^8.3.0"
     postcss-value-parser "^4.1.0"
     semver "^5.4.1"
 
-"@parcel/transformer-html@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-html/-/transformer-html-2.0.0-nightly.755.tgz#71e220053a0c066f2bd034fcea8d44a48ed9de3c"
-  integrity sha512-Xw14OzbvCCQPNXXgX0uKSQ8zro3VUgKYCgp3ySzntwCCxF950yolYgcybmOXqUfx0qVrnYso8L/sGCcJq1bPJw==
+"@parcel/transformer-html@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-html/-/transformer-html-2.0.0-nightly.778.tgz#c48091cf2a4b6f7e8fd013599f60df0ee6be0e32"
+  integrity sha512-31vHwWz6+H6YEUQ7MDX+PraZTQMCt48/fqzhsrly9chefCHfF2pQLpQBjY27MxB5nsEzIQ58fNurQ7afQWN9Qw==
   dependencies:
-    "@parcel/hash" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
+    "@parcel/hash" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
     nullthrows "^1.1.1"
-    posthtml "^0.15.1"
+    posthtml "^0.16.4"
     posthtml-parser "^0.9.0"
-    posthtml-render "^1.4.0"
+    posthtml-render "^2.0.6"
     semver "^5.4.1"
 
-"@parcel/transformer-js@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-js/-/transformer-js-2.0.0-nightly.755.tgz#feac399f4e440f94216ef96474aa8b1fc4b54f4a"
-  integrity sha512-Rcu6tZXgxq1VHhOCNuMo8HfvGF3L5fS9u88jpdtU6t13HLUb1UKgC/XnxHYL0STaABeWPcTWsiBxw6oliQZtpw==
+"@parcel/transformer-js@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-js/-/transformer-js-2.0.0-nightly.778.tgz#0790767ca0ad539e7c5b4e9b513cbf7a1f23a208"
+  integrity sha512-ssujk9AOTAAzianhlOny/6RHBTebOwQnCnxfUBJMdhzophvQ0rbRumeymEWgn5OUHzl7FX/zhAkQXprZOJIXzQ==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     "@swc/helpers" "^0.2.11"
     browserslist "^4.6.6"
     detect-libc "^1.0.3"
@@ -754,22 +755,22 @@
     regenerator-runtime "^0.13.7"
     semver "^5.4.1"
 
-"@parcel/transformer-json@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-json/-/transformer-json-2.0.0-nightly.755.tgz#4605e85f68ce9463cda72b192945b12e96c16354"
-  integrity sha512-S2f6tSmIIg7hqfFJn5ahVOQeSzKYgdWa8y0YLKBm5taf7iEalkonJOyfC5oYMUWrW3YIidXvE0CgQnUNmy7jqg==
+"@parcel/transformer-json@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-json/-/transformer-json-2.0.0-nightly.778.tgz#a12ad4b77fc22f1f27bb77e6fef44d1be4ff0a0b"
+  integrity sha512-Og9dWCqkEVIhea5IUpVnMmQf5gbNDUPhDtXtiklx3NdY/wethSq9kP/zGGYQNwQ+3D2vrAHsFjyFNAHEE2cpGw==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
     json5 "^2.1.0"
 
-"@parcel/transformer-postcss@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-postcss/-/transformer-postcss-2.0.0-nightly.755.tgz#7fd6ed756e3748d792111fa2e88845c00b6e9800"
-  integrity sha512-jeDLjE5DbhSh6mwk6lV+NCKI9VEQAe0gYFTljfh85mU+7zrIyUbNjERlpek/4JhQiUpVaRGUfezNssft2BUUhw==
+"@parcel/transformer-postcss@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-postcss/-/transformer-postcss-2.0.0-nightly.778.tgz#aedbb4343434ab77715802796384ed21d2b33d2e"
+  integrity sha512-djDuA3OnpDsD5jwiSAZdKxWLN857eQB4d2A+NSaKct2zHgUoHjQAcou/P+F5wki1x8Ze1LG82mIKhZHj/FcRHg==
   dependencies:
-    "@parcel/hash" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/hash" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     clone "^2.1.1"
     css-modules-loader-core "^1.1.0"
     nullthrows "^1.1.1"
@@ -777,75 +778,75 @@
     postcss-value-parser "^4.1.0"
     semver "^5.4.1"
 
-"@parcel/transformer-posthtml@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-posthtml/-/transformer-posthtml-2.0.0-nightly.755.tgz#260a31e43eef86de466a13b01a2787f77dc71557"
-  integrity sha512-97lZqaijnR0FTpKFifD2iNSMeL6eWuoHzsess5wMQK7VnhMaC2XiHl/8/IpSx9uDJJMv7IZRQJ0PkLLxdI1eIQ==
+"@parcel/transformer-posthtml@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-posthtml/-/transformer-posthtml-2.0.0-nightly.778.tgz#732bc1f2970bc469c949320233c769d9354d25b4"
+  integrity sha512-UIO5O40dOEnFB7/rFGfRS+TgV7nE62TXLG6p+vEXAGsuhJBlvDFbH+61udrZsBM97oWE0GTHokIWhOB4kXObsg==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     nullthrows "^1.1.1"
-    posthtml "^0.15.1"
+    posthtml "^0.16.4"
     posthtml-parser "^0.9.0"
-    posthtml-render "^1.4.0"
+    posthtml-render "^2.0.6"
     semver "^5.4.1"
 
-"@parcel/transformer-raw@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-raw/-/transformer-raw-2.0.0-nightly.755.tgz#f70c4bc7932ee4999792bc401f617676cf6241f7"
-  integrity sha512-m8tXyxeuaa3IW+kIvOeQR0La8IGbFp8kWPa4m2GG3+J/cT83xH9/dC4iOEAo+EbGraab9151iMAZu/B5dqvbdA==
+"@parcel/transformer-raw@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-raw/-/transformer-raw-2.0.0-nightly.778.tgz#e276ac18b05816c7656343ef8cdaba6abeef65d1"
+  integrity sha512-K9bUWHanBKyQiZ1nf55MKCN3TPPe67F7iLwKkam8WFSfdaOd4Bc2bJASUKusCVUn8R2C0sJ7q5XHWyncWoyMFA==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
 
-"@parcel/transformer-react-refresh-wrap@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.0.0-nightly.755.tgz#097c2d01be33936a0374037cb178298f25315e60"
-  integrity sha512-vQ5TyZQ4SRQgTCEabGX3oXfngfxGrQW0LHEhUQuk1awGFKyIDtCQrVi5wCJcnx9KbNI6SHBMARCEGcHUk+lnEQ==
+"@parcel/transformer-react-refresh-wrap@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.0.0-nightly.778.tgz#6118713e5c7f8a09edd603c21f35ee78506d5da6"
+  integrity sha512-Y2SVS2fTOwUIvE8va5uiqk3GdBRues8lcBd3KJAl9WKb8dwjuLNiS4giaJ0cBDRN/5aNaKnJB/AiphqLxfmZ8g==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     react-refresh "^0.9.0"
 
-"@parcel/transformer-typescript-tsc@^2.0.0-beta.3.1":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/transformer-typescript-tsc/-/transformer-typescript-tsc-2.0.0-nightly.755.tgz#11bc56abf0a2b988c01760409bf4dac53f1f6b32"
-  integrity sha512-gMsPUU/0igfUeCl9CYVWvbV++FQGZ1cKAzduR/lrPTeNbSYrhltlYWo/F68AaX70o7RkGdCz6NLEo+JoKVGMYA==
+"@parcel/transformer-typescript-tsc@nightly":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/transformer-typescript-tsc/-/transformer-typescript-tsc-2.0.0-nightly.778.tgz#735fc6af8ffc9e5110f8170e61e9731cff0719cd"
+  integrity sha512-huN7KWVA+LIDKgQ0l5R+g4Batjv8VN+67pym/VUYhWveLxV+tXWtXjTHv5qnKOq7qvZkHRcIWwPVLRytICpyYQ==
   dependencies:
-    "@parcel/plugin" "2.0.0-nightly.755+79923ce5"
-    "@parcel/ts-utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/plugin" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/ts-utils" "2.0.0-nightly.778+ba7d2263"
 
-"@parcel/ts-utils@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/ts-utils/-/ts-utils-2.0.0-nightly.755.tgz#8844d983098b4e0e25303a1c39c5264078a43b71"
-  integrity sha512-zC82qolUvA0LLDhr6JrBGBJKiM7I8Y+KccDpgxGJ9GArN0rVyoWDDy/CFBXv4L4K4MW2Jg5sF5sGtEJ2Eow78A==
+"@parcel/ts-utils@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/ts-utils/-/ts-utils-2.0.0-nightly.778.tgz#11d3e7f650c57c8a208136ebb8bae495d058324a"
+  integrity sha512-1cfk4eYO8mFr3wHpC2r88IbJarumRsUX0c5C3I+qH38vFXsWMzv41ZnVFlNO7dqUWy1iyK4w8CsfsJsVttEBEA==
   dependencies:
     nullthrows "^1.1.1"
 
-"@parcel/types@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/types/-/types-2.0.0-nightly.755.tgz#1eb78086f03426d2625b4aa0fcd6d03d4d6fcc4f"
-  integrity sha512-1KAytYT3GWI8wpdqCepwZNZtMWJlMYsFiiZ2HRzxrjXfZ1QSf1Jifd9iAhTTJotLNflEBbXyEfRhx9gAhua2hQ==
+"@parcel/types@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/types/-/types-2.0.0-nightly.778.tgz#a6751d25acbe063cf7a8e2b7d50dc78c43d3588c"
+  integrity sha512-6bu1V3hdcEvBmllqMC6wl3gHFAYsD1FeJo0g3Td4gFg23+7BCjuzAL/TLiGnWvAfRpw60RDh2EZp9yL7Ys4Avw==
   dependencies:
-    "@parcel/cache" "2.0.0-nightly.755+79923ce5"
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/fs" "2.0.0-nightly.755+79923ce5"
-    "@parcel/package-manager" "2.0.0-nightly.755+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
-    "@parcel/workers" "2.0.0-nightly.755+79923ce5"
+    "@parcel/cache" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/fs" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/package-manager" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
+    "@parcel/workers" "2.0.0-nightly.778+ba7d2263"
     utility-types "^3.10.0"
 
-"@parcel/utils@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/utils/-/utils-2.0.0-nightly.755.tgz#4157ff65bcfd2e64a997f914e68239d31cece9e9"
-  integrity sha512-0GJTUL0V5NFJyJqPU/iXb2kXAMdUiBXipE7+SKnUmNqPZoOF9IvznX+SK4AaEQxAQZr4ftpJNCk9zXH8tXIeGA==
+"@parcel/utils@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/utils/-/utils-2.0.0-nightly.778.tgz#19dc3ff79902ae15ce0ad2521a350ff9ec57521f"
+  integrity sha512-drqeNt9uV5QyGzGXUrwUQrAnTRoAPSXqFOXOHFh3a6ieadYN2xK+oX+lUXn9QASxar0M2j4y4E1VpE3YX+6Thg==
   dependencies:
     "@iarna/toml" "^2.2.0"
-    "@parcel/codeframe" "2.0.0-nightly.755+79923ce5"
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/hash" "2.0.0-nightly.2377+79923ce5"
-    "@parcel/logger" "2.0.0-nightly.755+79923ce5"
-    "@parcel/markdown-ansi" "2.0.0-nightly.755+79923ce5"
-    "@parcel/source-map" "2.0.0-rc.4"
+    "@parcel/codeframe" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/hash" "2.0.0-nightly.2400+ba7d2263"
+    "@parcel/logger" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/markdown-ansi" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/source-map" "2.0.0-rc.5"
     ansi-html "^0.0.7"
     chalk "^4.1.0"
     clone "^2.1.1"
@@ -855,7 +856,7 @@
     is-url "^1.2.2"
     json5 "^1.0.1"
     lru-cache "^6.0.0"
-    micromatch "^4.0.2"
+    micromatch "^3.0.4"
     node-forge "^0.10.0"
     nullthrows "^1.1.1"
     open "^7.0.3"
@@ -868,15 +869,15 @@
     node-addon-api "^3.0.2"
     node-gyp-build "^4.2.3"
 
-"@parcel/workers@2.0.0-nightly.755+79923ce5":
-  version "2.0.0-nightly.755"
-  resolved "https://registry.yarnpkg.com/@parcel/workers/-/workers-2.0.0-nightly.755.tgz#766c2e7de38d890fceb7d351440be4e005b4ed33"
-  integrity sha512-km9r23n+JH1s8lJRqNrjnhYY9mwotHbsJVY9jUGSkm7lSJFzmJ581basWPb6uX2IaFw7Qpz2VOOED/g4TyQdfw==
+"@parcel/workers@2.0.0-nightly.778+ba7d2263":
+  version "2.0.0-nightly.778"
+  resolved "https://registry.yarnpkg.com/@parcel/workers/-/workers-2.0.0-nightly.778.tgz#591e7ad9464abd30c75bc3adaff92c5b1842da47"
+  integrity sha512-Mc+AZz2zWsq5glwyOsgCTvdMijFnHy+wGelDi8vOaIxF0KQd5EZeukhdKzqG70kKZ0R4C4/K6QtESaVe7V+Tbg==
   dependencies:
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/logger" "2.0.0-nightly.755+79923ce5"
-    "@parcel/types" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/logger" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/types" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     chrome-trace-event "^1.0.2"
     nullthrows "^1.1.1"
 
@@ -2991,6 +2992,11 @@ is-interactive@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
+is-json@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-json/-/is-json-2.0.1.tgz#6be166d144828a131d686891b983df62c39491ff"
+  integrity sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8=
+
 is-nan@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
@@ -3762,21 +3768,21 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
-parcel@^2.0.0-beta.3.1:
-  version "2.0.0-nightly.753"
-  resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.0.0-nightly.753.tgz#3d62e24fcbae64014a9d05ab9115ece001366f4a"
-  integrity sha512-Iq1IOi0DvpwhdDvoZA541CKQATWiIfR5FGBAh9vxFsJmXelPRbBXLHjIlSgrqy410hbVjvTYC19+FTsttnrjBA==
+parcel@nightly:
+  version "2.0.0-nightly.776"
+  resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.0.0-nightly.776.tgz#ff8a9e306f127300fc1aa8a5babeebc7a26936ae"
+  integrity sha512-LG8vVsaqSQVpu/6dhXYAwKmjtLCP8CSMmpCN8mbRUZbEnXQ0TC1Zt+o8/mUaYeMVhaNeV8OjZUB7Eoh4hDZNqA==
   dependencies:
-    "@parcel/config-default" "2.0.0-nightly.755+79923ce5"
-    "@parcel/core" "2.0.0-nightly.753+79923ce5"
-    "@parcel/diagnostic" "2.0.0-nightly.755+79923ce5"
-    "@parcel/events" "2.0.0-nightly.755+79923ce5"
-    "@parcel/fs" "2.0.0-nightly.755+79923ce5"
-    "@parcel/logger" "2.0.0-nightly.755+79923ce5"
-    "@parcel/package-manager" "2.0.0-nightly.755+79923ce5"
-    "@parcel/reporter-cli" "2.0.0-nightly.755+79923ce5"
-    "@parcel/reporter-dev-server" "2.0.0-nightly.755+79923ce5"
-    "@parcel/utils" "2.0.0-nightly.755+79923ce5"
+    "@parcel/config-default" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/core" "2.0.0-nightly.776+ba7d2263"
+    "@parcel/diagnostic" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/events" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/fs" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/logger" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/package-manager" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/reporter-cli" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/reporter-dev-server" "2.0.0-nightly.778+ba7d2263"
+    "@parcel/utils" "2.0.0-nightly.778+ba7d2263"
     chalk "^4.1.0"
     commander "^7.0.0"
     get-port "^4.2.0"
@@ -4267,18 +4273,28 @@ posthtml-render@^1.3.1:
   resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.3.1.tgz#260f15bc43cdf7ea008bf0cc35253fb27e4d03fd"
   integrity sha512-eSToKjNLu0FiF76SSGMHjOFXYzAc/CJqi677Sq6hYvcvFCBtD6de/W5l+0IYPf7ypscqAfjCttxvTdMJt5Gj8Q==
 
-posthtml-render@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.4.0.tgz#40114070c45881cacb93347dae3eff53afbcff13"
-  integrity sha512-W1779iVHGfq0Fvh2PROhCe2QhB8mEErgqzo1wpIt36tCgChafP+hbXIhLDOM8ePJrZcFs0vkNEtdibEWVqChqw==
+posthtml-render@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-2.0.6.tgz#f39035b133f1cea1a879cba3982a7eaa1fc06c34"
+  integrity sha512-AvjM4yfEtjhbpZdtLOWfnezgojEtgeejSxrjTAvfr5phXjPcZQyB5QiOvYeU+rrTF0u+eqqlJrs8HS3nrPexGQ==
+  dependencies:
+    is-json "^2.0.1"
 
-posthtml@^0.15.1, posthtml@^0.15.2:
+posthtml@^0.15.2:
   version "0.15.2"
   resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.15.2.tgz#739cf0d3ffec70868b87121dc7393478e1898c9c"
   integrity sha512-YugEJ5ze/0DLRIVBjCpDwANWL4pPj1kHJ/2llY8xuInr0nbkon3qTiMPe5LQa+cCwNjxS7nAZZTp+1M+6mT4Zg==
   dependencies:
     posthtml-parser "^0.7.2"
     posthtml-render "^1.3.1"
+
+posthtml@^0.16.4:
+  version "0.16.4"
+  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.16.4.tgz#4f9b326357a39a820376fb065aa55bb1d313c97a"
+  integrity sha512-32VVeMtkoUrWI84etFPBBhOOJS19WAJDxJMLYi3dKma2sPtDDpO2CrR5dV8rVMPwZoAeVYxIdpaE4aqY12ibOA==
+  dependencies:
+    posthtml-parser "^0.9.0"
+    posthtml-render "^2.0.6"
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Update to the nighty versions for `parcel` and `@parcel/transformer-typescript-tsc` to see if it'll fix the ESM issues. See https://github.com/parcel-bundler/parcel/issues/6639#issuecomment-886259317